### PR TITLE
Fix single quotes problem in code editor, changed res.send

### DIFF
--- a/app/components/Terminal.jsx
+++ b/app/components/Terminal.jsx
@@ -7,22 +7,28 @@ class Terminal extends React.Component {
 		super(props);
     var context = this;
 		this.state = {
-			command: null
+			command: null,
+      prompt: null,
+      containerName: 'juice' // change this to refer to user name when login is done
 		}
     this.renderTerminal();
 	}
 
+
+
   renderTerminal() {
-    // console.log('render terminal');
-    console.log($);
-    console.log($.terminal);
+    // console.log($);
+    // console.log($.terminal);
+
+    var prompt = this.state.prompt ? this.state.prompt + '>> ' : '>> ';
+    var containerName = this.state.containerName;
 
     $(function($, undefined) {
       $('#terminal').terminal(function(command, term) {
         console.log('command', command);
         if (command !== '') {
 
-          axios.post('/cmd', { cmd: command })
+          axios.post('/cmd', { cmd: command, containerName: containerName })
             .then(function(res) {
               console.log(res);
               console.log(res.data);
@@ -31,20 +37,29 @@ class Terminal extends React.Component {
             .catch(function(err) {
               console.error(err);
               term.echo(String(err));
-            })
+            });
 
             // var result = window.eval(command);
-            // console.log('result', result);
-            // if (result != undefined) {
-            //     term.echo(String(result));
-            // }
         }
       }, {
           greetings: '',
           name: '',
           height: 500,
           width: 650,
-          prompt: '>> '
+          prompt: prompt,
+          onInit: function(term) {
+            console.log('started terminal');
+            var command = 'cd /picoShell';
+            axios.post('/cmd', { cmd: command, containerName: containerName })
+              .then(function(res) {
+                console.log(res);
+                term.echo(String(res.data));
+              })
+              .catch(function(err) {
+                console.error(err);
+                term.echo(String(err));
+              });
+          }
       });
     });
   }

--- a/app/components/Terminal.jsx
+++ b/app/components/Terminal.jsx
@@ -42,7 +42,7 @@ class Terminal extends React.Component {
       }, {
           greetings: '',
           name: '',
-          height: 600,
+          height: 500,
           width: 650,
           prompt: '>> '
       });

--- a/routes/index.js
+++ b/routes/index.js
@@ -38,6 +38,7 @@ router.post('/handleCodeSave', function (req, res) {
 
 router.post('/cmd', function (req, res) {
   var cmd = req.body.cmd;
+  var containerName = req.body.containerName;
 
   if(cmd.split(" ")[0] === 'cd') {
     const newdir = cmd.split(" ")[1];
@@ -45,16 +46,13 @@ router.post('/cmd', function (req, res) {
 
     const command = 'bash -c "echo ' + newdir + ' > /picoShell/.pico' + '"'; 
     console.log(command);
-    docker.runCommand('juice', command, function(err, res1) {
-      if (err) {
-        res.status(200).send(err);
-      } else {
-        res.status(200).send(res1);
-      }
+    docker.runCommand(containerName, command, function(err, res1) {
+      if (err) { res.status(200).send(err); } 
+      else { res.status(200).send(res1); }
     })
   }
   else {
-    docker.runCommand('juice', 'cat /picoShell/.pico', function(err1, res1) {
+    docker.runCommand(containerName, 'cat /picoShell/.pico', function(err1, res1) {
 
       console.log('response from cat /picoShell/.pico :', res1);
       res1 = res1.replace(/^\s+|\s+$/g, '');
@@ -62,12 +60,9 @@ router.post('/cmd', function (req, res) {
       cmd = '"cd ' + res1 + ' && ' + cmd + '"';
       const command = 'bash -c ' + cmd;
       console.log(command);
-      docker.runCommand('juice', command, function(err2, res2) {
-        if (err2) {
-          res.status(200).send(err2);
-        } else {
-          res.status(200).send(res2);
-        }
+      docker.runCommand(containerName, command, function(err2, res2) {
+        if (err2) { res.status(200).send(err2); } 
+        else { res.status(200).send(res2); }
       });
     })
     

--- a/routes/index.js
+++ b/routes/index.js
@@ -17,16 +17,21 @@ router.get('/', function(req, res) {
 });
 
 router.post('/handleCodeSave', function (req, res) {
-  const code = JSON.stringify(req.body.codeValue).replace("'", "'\\''");
+  // const code = JSON.stringify(req.body.codeValue);
+  // console.log(req.body.codeValue);
+  // console.log(JSON.stringify(req.body.codeValue));
+  // console.log(JSON.stringify(req.body.codeValue).replace(/'/g, "\\\""));
+
+  const code = JSON.stringify(req.body.codeValue).replace(/'/g, "\\\"");
   const echo = "'echo -e ";
   const file = " > juice.js'";
   const command = 'bash -c ' + echo + code + file;
   console.log(command);
   docker.runCommand('juice', command, function(err, response) {
     if (err) {
-      res.send(200, err);
+      res.status(200).send(err);
     } else {
-      res.send(200, response);
+      res.status(200).send(response);
     }
   });
 });
@@ -42,9 +47,9 @@ router.post('/cmd', function (req, res) {
     console.log(command);
     docker.runCommand('juice', command, function(err, res1) {
       if (err) {
-        res.send(200, err);
+        res.status(200).send(err);
       } else {
-        res.send(200, res1);
+        res.status(200).send(res1);
       }
     })
   }
@@ -59,9 +64,9 @@ router.post('/cmd', function (req, res) {
       console.log(command);
       docker.runCommand('juice', command, function(err2, res2) {
         if (err2) {
-          res.send(200, err2);
+          res.status(200).send(err2);
         } else {
-          res.send(200, res2);
+          res.status(200).send(res2);
         }
       });
     })


### PR DESCRIPTION
Allow code editor to use single quotes and double quotes.
Changed the way res.send is done because old way is deprecated.